### PR TITLE
Correction fond lors du passage en fullscreen

### DIFF
--- a/reveal/theme-zenika/theme.css
+++ b/reveal/theme-zenika/theme.css
@@ -518,3 +518,12 @@ body {
   font-family: 'FontAwesome';
   font-style: normal;
 }
+
+/** contournement bug chrome et ff qui affichent un fond noir lors du passage en fullscreen */
+html:-webkit-full-screen-ancestor {
+  background-color: inherit;
+}
+
+html {
+  background-color: #fff !important;
+}

--- a/reveal/theme-zenika/theme.css
+++ b/reveal/theme-zenika/theme.css
@@ -519,7 +519,7 @@ body {
   font-style: normal;
 }
 
-/** contournement bug chrome et ff qui affichent un fond noir lors du passage en fullscreen */
+/** contournement bug chrome et ff qui affichent un fond noir lors du passage en fullscreen : cf https://github.com/hakimel/reveal.js/issues/1386#issuecomment-225379825 */
 html:-webkit-full-screen-ancestor {
   background-color: inherit;
 }


### PR DESCRIPTION
En version 49 de firefox et 53.0.2785.143 de chrome, lors du passage en fullscreen de la présentation, le fond d'écran et des slides passent en noir.

Cette PR corrige ces pb en attendant la resynchro avec une version plus récente de reveal.js
cf : https://github.com/hakimel/reveal.js/issues/1386#issuecomment-225379825

<img width="1280" alt="capture d ecran 2016-10-12 a 21 27 45" src="https://cloud.githubusercontent.com/assets/7294764/19324608/c5b0a2a6-90c2-11e6-931e-55844f02e210.png">
