### PR TITLE
Lors d'une impression, 1 page sur 2 est blanche

### DIFF
--- a/reveal/theme-zenika/pdf.css
+++ b/reveal/theme-zenika/pdf.css
@@ -13,8 +13,8 @@ body {
 }
 
 .reveal .slides section section {
-  height: 210mm !important;
-  min-height: 210mm !important;
+  height: 209mm !important;
+  min-height: 209mm !important;
   padding: 0 70px !important;
 }
 


### PR DESCRIPTION
Lors d'une impression, 1 page sur 2 est blanche : 
<img width="1280" alt="avant" src="https://cloud.githubusercontent.com/assets/7294764/19831448/9f908f8c-9e0a-11e6-9447-75ab52ec4d89.png">

En diminuant la hauteur de la section, le pb est corrigé : 
<img width="1280" alt="apres" src="https://cloud.githubusercontent.com/assets/7294764/19831451/b47cffc0-9e0a-11e6-9eea-108ac006e78e.png">

Je me doute bien qu'il faut trouver d'où vient ce foutu pixel d'écart (une page fait 210 mm, je fixe la taille de la section à 209 mm au lieu de 210mm) mais je ne trouve pas mieux.
