### PR TITLE
chore(#130): deploy bin script

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -17,6 +17,7 @@ if (!serviceAccount || !currentBranch) {
 fs.writeFileSync(tempKeyFile, process.env.GAE_KEY_FILE_CONTENT)
 try {
   execFileSync('gcloud', ['config', 'set', 'app/use_appengine_api', 'false'])
+  execFileSync('gcloud', ['config', 'set', 'app/promote_by_default', 'false'])
   console.log('Authenticate with', serviceAccount)
   execFileSync('gcloud', ['auth', 'activate-service-account', serviceAccount, '--key-file', tempKeyFile])
   console.log('Deploying to', deployName)

--- a/deploy.js
+++ b/deploy.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const execFileSync = require('child_process').execFileSync
+const fs = require('fs')
+
+const tempKeyFile = 'file.key'
+const serviceAccount = process.env.GAE_SERVICE_ACCOUNT
+const deployName = process.env.npm_package_config_deploy_name
+const currentBranch = process.env.CURRENT_BRANCH
+
+if (!serviceAccount || !currentBranch) {
+  console.log('Environment variables GAE_SERVICE_ACCOUNT or CURRENT_BRANCH not set.')
+  console.log('Please check both are defined when running this script.')
+  process.exit(1)
+}
+
+fs.writeFileSync(tempKeyFile, process.env.GAE_KEY_FILE_CONTENT)
+try {
+  execFileSync('gcloud', ['config', 'set', 'app/use_appengine_api', 'false'])
+  console.log('Authenticate with', serviceAccount)
+  execFileSync('gcloud', ['auth', 'activate-service-account', serviceAccount, '--key-file', tempKeyFile])
+  console.log('Deploying to', deployName)
+  execFileSync('gcloud', ['--project', deployName, 'preview', 'app', 'deploy', '--version', currentBranch, '--quiet', 'dist/app.yaml'])
+} finally {
+  fs.unlinkSync(tempKeyFile)
+}

--- a/gcloud-deploy.sh
+++ b/gcloud-deploy.sh
@@ -1,6 +1,0 @@
-echo $GAE_KEY_FILE_CONTENT > file.key
-google-cloud-sdk/bin/gcloud config set app/use_appengine_api false
-echo "Authenticate with $GAE_SERVICE_ACCOUNT"
-google-cloud-sdk/bin/gcloud auth activate-service-account $GAE_SERVICE_ACCOUNT --key-file file.key
-echo "Deploying to FORMATION_DEPLOY_NAME"
-google-cloud-sdk/bin/gcloud --project FORMATION_DEPLOY_NAME preview app deploy --version $CURRENT_BRANCH --quiet dist/app.yaml

--- a/gcloud-install.sh
+++ b/gcloud-install.sh
@@ -1,7 +1,0 @@
-echo "Downloading google cloud sdk";
-wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip;
-unzip -qq google-cloud-sdk.zip;
-export CLOUDSDK_COMPONENT_MANAGER_FIXED_SDK_VERSION=0.9.86;
-google-cloud-sdk/install.sh --usage-reporting false --path-update false --rc-path=~/.bashrc --bash-completion false;
-google-cloud-sdk/bin/gcloud config set --scope=installation component_manager/fixed_sdk_version $CLOUDSDK_COMPONENT_MANAGER_FIXED_SDK_VERSION;
-google-cloud-sdk/bin/gcloud components update --quiet;

--- a/package.json
+++ b/package.json
@@ -28,5 +28,11 @@
     "reveal.js": "^2.6.2",
     "split": "^0.3.3",
     "through": "^2.3.6"
+  },
+  "engines": {
+    "node": ">=4"
+  },
+  "bin": {
+    "zenika-formation-deploy": "deploy.js"
   }
 }


### PR DESCRIPTION
Cette PR remplace le script `gcloud-deploy.sh` par un équivalent en JS, ce qui permet au framework de l'exposer en tant qu'exécutable aux formations qui dépendent de lui. Elle peuvent alors l'utiliser dans leurs scripts npm. Ceci permet aux formations de ne plus avoir à appeler `gcloud-deploy.sh` manuellement, ce qui pose des problèmes de permissions (cf #130).