### PR TITLE
fix(#122): Base Dockerfile on a node-alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # zenika/formations
-FROM node:7.2
+FROM node:7.2-alpine
 MAINTAINER Zenika <http://www.zenika.com>
 
 # Install grunt


### PR DESCRIPTION
There is now an official apline-flavored node docker image.