### PR TITLE
Centrer le titre sur la page d'accueil

### DIFF
--- a/reveal/theme-zenika/pdf.css
+++ b/reveal/theme-zenika/pdf.css
@@ -12,6 +12,11 @@ body {
   }
 }
 
+.reveal section.page-title h1 {
+  display: block;
+  padding-top: 20%;
+}
+
 .reveal .slides section section {
   height: 209mm !important;
   min-height: 209mm !important;

--- a/reveal/theme-zenika/theme.css
+++ b/reveal/theme-zenika/theme.css
@@ -233,15 +233,13 @@ body {
 .reveal section.page-title h1 {
   height: 90%;
   display: flex;
+  flex-flow: column;
   align-items: center;
   justify-content: center;
   margin: auto;
   text-align: center;
   color: white;
   float: none;
-}
-.reveal section.page-title h1 img {
-  display: inline-block;
 }
 
 .reveal section.page-title ul {


### PR DESCRIPTION
[Zenika-Formation-formation-angularjs-Slides.pdf](https://github.com/Zenika/zenika-formation-framework/files/790903/Zenika-Formation-formation-angularjs-Slides.pdf)
[Zenika-Formation-Git-Slides.pdf](https://github.com/Zenika/zenika-formation-framework/files/790904/Zenika-Formation-Git-Slides.pdf)

C'est moins clean qu'avec du flex, mais ça marche avec les pdf