### PR TITLE
fix(#180) wrong theme for <em> and <strong>

### DIFF
--- a/reveal/theme-zenika/theme.css
+++ b/reveal/theme-zenika/theme.css
@@ -157,12 +157,12 @@ body {
 
 .reveal em {
   color: #b30c37;
-  font-style: normal;
+  font-style: italic;
 }
 
 .reveal strong {
   color: #b30c37;
-  font-style: italic;
+  font-style: normal;
   font-weight: normal;
 }
 


### PR DESCRIPTION
Attention Breaking Changes ! On devra repasser sur toutes les formations pour transformer le Markdown. 

```
*JavaScript* devra être remplacé en **JavaScript**
```

Un seul * correspond à de l'italique, mais il était jusqu'à présent affiché en bold. 