### PR TITLE
chore(deploy): fixed displayed url when deploying

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -8,7 +8,7 @@ if (require.main === module) { // or else the Gruntfile from the depending proje
   const gcloudSdkVersion = '135.0.0'
   const serviceAccount = process.env.GAE_SERVICE_ACCOUNT
   const gcloudProject = 'zen-formations'
-  const gcloudService = process.env.npm_package_config_deploy_name
+  const gcloudService = process.env.npm_package_name
   const currentBranch = process.env.CURRENT_BRANCH
 
   if (!serviceAccount || !currentBranch) {


### PR DESCRIPTION
`config.deploy.name` is longer used for deployment. Was replaced with `name`.