### PR TITLE
Sous chrome 61 les numéros de TP ne sont plus visible

### DIFF
--- a/reveal/theme-zenika/theme.css
+++ b/reveal/theme-zenika/theme.css
@@ -263,7 +263,7 @@ body {
 
 }
 .reveal section [class^="page-tp"]:after {
-  display: inline-block;
+  display: block;
   color: #af1e3a;
   font-size: 50px;
   font-weight: bold;

--- a/reveal/theme-zenika/theme.css
+++ b/reveal/theme-zenika/theme.css
@@ -258,7 +258,7 @@ body {
   height: 80%;
 }
 .reveal section [class^="page-tp"] {
-  background: transparent center center no-repeat url('./images/tp.svg');
+  background: white center center no-repeat url('./images/tp.svg');
   background-size: 60%;
 
 }


### PR DESCRIPTION
Exemple : https://formation-go-dot-zen-formations.appspot.com/slides.html#/2/10