### PR TITLE
:wrench: Update gitignore for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .idea
+.vscode
 *.iml
 dist
 *.log


### PR DESCRIPTION
Ajouter le dossier `.vscode` au gitignore pour permettre de configurer sont éditeur sans tout polluer.