### PR TITLE
feat: give the possibility to have materials specific to a country

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,7 @@ module.exports = function gruntConfig(grunt) {
 
   const slidesFolder = grunt.option('slides-folder') || 'Slides';
   const labsFolder = grunt.option('labs-folder') || 'CahierExercices';
+  const locale = grunt.option('locale') || 'fr';
 
   function resolveNpmModulesPath(npmModulePath) {
     try {
@@ -38,7 +39,7 @@ module.exports = function gruntConfig(grunt) {
     dist: 'dist',
     connect: {
       options: {
-        base: [frameworkPath, `${slidesFolder}/`, pathIfNpm2(''), pathIfNpm3('')],
+        base: [frameworkPath, `${slidesFolder}/${locale}/`, `${slidesFolder}/`, pathIfNpm2(''), pathIfNpm3('')],
         hostname: '0.0.0.0',
         port,
       },
@@ -307,13 +308,16 @@ module.exports = function gruntConfig(grunt) {
 
     let parts;
     try {
-      parts = require(path.resolve(frameworkPath, '..', '..', labsFolder, 'parts.json'));
+      parts = require(path.resolve(process.cwd(), labsFolder, 'parts.json'));
     } catch (e) {
       parts = ['Cahier.md'];
     }
     const cssPath = path.resolve(frameworkPath, 'styleCahierExercice.css');
     const highlightPath = path.resolve(frameworkPath, 'reveal', 'theme-zenika', 'code.css');
-    const files = parts.map(file => path.resolve(labsFolder, file));
+    const files = parts.map((file) => {
+      const localizedPath = path.resolve(labsFolder, locale, file);
+      return fs.existsSync(localizedPath) ? localizedPath : path.resolve(labsFolder, file);
+    });
 
     console.log('Using CSS file', cssPath);
     console.log('Using highlightPath file', highlightPath);


### PR DESCRIPTION
After a talk with @ncuillery and @T3kstiil3 about trainings materials, here is a POC if we want to make our materials specific for an agency / country / ...

We just need, for both slides and PW, create a specific folder for the agency (let say `ca` for canada), and use the new locale CLI parameter. If for exanple, I want to create a specific version of the PW file `PW1.md`, we juste need to create a `/ca/PW1.md` file. 

Thanks to this first architecture, we can make a complete chapter / PW specific to an agency. 

Next step, have a look if it is possible to make this behavior possible for specific slides (and not the complete chapter)

I also updated the repo `Formation--Modele`  https://github.com/Zenika/Formation--Modele/pull/136

What do you think ?