### PR TITLE
💄 use theme 2017 by default

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -414,7 +414,6 @@ module.exports = function gruntConfig(grunt) {
   });
 
   grunt.registerTask('doGenerateSlidesPDF', async function doGenerateSlidesPDF() {
-    const theme = grunt.option('old-theme') ? '' : 'theme-2017'
     const done = this.async();
     try {
       const pdf = await generatePdfAt(`http://localhost:${port}?print-pdf&${theme}`, {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,6 +16,7 @@ module.exports = function gruntConfig(grunt) {
   const slidesFolder = grunt.option('slides-folder') || 'Slides';
   const labsFolder = grunt.option('labs-folder') || 'CahierExercices';
   const locale = grunt.option('locale') || 'fr';
+  const theme = grunt.option('old-theme') ? '' : 'theme-2017'
 
   function resolveNpmModulesPath(npmModulePath) {
     try {
@@ -47,7 +48,7 @@ module.exports = function gruntConfig(grunt) {
         options: {
           livereload: 32729,
           open: {
-            target: `http://localhost:${port}/?theme-2017`,
+            target: `http://localhost:${port}/?${theme}`,
             // appName: 'chrome' // commenté temps de faire la bonne mécanique cross-OS
           },
         },
@@ -413,9 +414,10 @@ module.exports = function gruntConfig(grunt) {
   });
 
   grunt.registerTask('doGenerateSlidesPDF', async function doGenerateSlidesPDF() {
+    const theme = grunt.option('old-theme') ? '' : 'theme-2017'
     const done = this.async();
     try {
-      const pdf = await generatePdfAt(`http://localhost:${port}?print-pdf&theme-2017`, {
+      const pdf = await generatePdfAt(`http://localhost:${port}?print-pdf&${theme}`, {
         landscape: true,
         printBackground: true,
         format: 'A4',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,7 @@ module.exports = function gruntConfig(grunt) {
         options: {
           livereload: 32729,
           open: {
-            target: `http://localhost:${port}`,
+            target: `http://localhost:${port}/?theme-2017`,
             // appName: 'chrome' // commenté temps de faire la bonne mécanique cross-OS
           },
         },
@@ -415,7 +415,7 @@ module.exports = function gruntConfig(grunt) {
   grunt.registerTask('doGenerateSlidesPDF', async function doGenerateSlidesPDF() {
     const done = this.async();
     try {
-      const pdf = await generatePdfAt(`http://localhost:${port}?print-pdf`, {
+      const pdf = await generatePdfAt(`http://localhost:${port}?print-pdf&theme-2017`, {
         landscape: true,
         printBackground: true,
         format: 'A4',


### PR DESCRIPTION
:bug: Use 2017 theme by default for running (`npm start`/`grunt`) and pdf generation (`npm start pdf`/`grunt pdf`)
:sparkles: Add an `--old-theme` parameter for both commands to use the old theme