### PR TITLE
✨ add font-noto-emoji and config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN apt-get update && \
     libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
     ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
 
+COPY pdf/noto-conf/NotoColorEmoji.ttf /usr/share/fonts/truetype/noto/NotoColorEmoji.ttf
+COPY pdf/noto-conf/noto-color.conf /etc/fonts/conf.d/10-noto-color.conf
+RUN chmod 644 /usr/share/fonts/truetype/noto/NotoColorEmoji.ttf && fc-cache -f -v
+
 # Install grunt
 WORKDIR /data
 RUN npm install --quiet grunt@^0.4.5 && \

--- a/pdf/noto-conf/noto-color.conf
+++ b/pdf/noto-conf/noto-color.conf
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+
+  <match target="scan">
+    <test name="family">
+      <string>Noto Color Emoji</string>
+    </test>
+    <edit name="scalable" mode="assign">
+      <bool>true</bool>
+    </edit>
+  </match>
+
+</fontconfig>


### PR DESCRIPTION
Hey 👋 

A little PR to add emoji rendering in pdf : 

before : 
<img width="391" alt="Screenshot 2020-09-24 at 09 23 19" src="https://user-images.githubusercontent.com/1011902/94114065-1f08eb00-fe48-11ea-8427-5cd1c4e0b958.png">

after:
<img width="424" alt="Screenshot 2020-09-24 at 09 20 18" src="https://user-images.githubusercontent.com/1011902/94114111-2fb96100-fe48-11ea-80d6-fd6ca7c32f1a.png">

Emojis are a little glitchy... I think this is not a problem since the framework will soon be in EOL but if you know why this happening, I will be happy to amend this PR 👍 